### PR TITLE
Fix: readonly fields blanked on save in SubformRepeater

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.joget</groupId>
     <artifactId>subform_repeater</artifactId>
     <packaging>bundle</packaging>
-    <version>8.0.5</version>
+    <version>8.0.6</version>
     <name>subform_repeater</name>
     <url>https://www.joget.org</url>
     <properties>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.joget</groupId>
             <artifactId>wflow-core</artifactId>
-            <version>7.0-SNAPSHOT</version>
+            <version>8.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>

--- a/src/main/java/org/joget/Activator.java
+++ b/src/main/java/org/joget/Activator.java
@@ -7,7 +7,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 public class Activator implements BundleActivator {
-        public final static String VERSION = "8.0.5";
+        public final static String VERSION = "8.0.6";
 
 
     protected Collection<ServiceRegistration> registrationList;

--- a/src/main/java/org/joget/SubformRepeater.java
+++ b/src/main/java/org/joget/SubformRepeater.java
@@ -147,7 +147,7 @@ public class SubformRepeater extends Grid implements PluginWebSupport {
 
                     for (String uv : uniqueValues) {
                         if (!uv.isEmpty()) {
-                            String paramPrefix = uv + "_" + param;
+                            String paramPrefix = param + "_" + uv; // realign getRows(0 with createForm() matching the child element parameter naming the createForm()
                             String rId = formData.getRequestParameter(paramPrefix + "_" + FormUtil.PROPERTY_ID);
                             FormRow r = null;
                             if ("disable".equals(getPropertyString("editMode")) && rId != null && !rId.isEmpty() && existing.containsKey(rId)) {


### PR DESCRIPTION
## Problem

In a SubformRepeater, child fields configured as `readonly:"true"` lose their value on save — the previously-loaded value is written back to the database as an empty string, overwriting existing data. Load shows the value; save wipes it.

## Root cause

Regression introduced by commit `e4bc19d` ("Fixed: Not working in Multi Paged Form"). That commit changed the child-element parameter naming built in `createForm()`:

```java
// before: <uniqueValue>_<gridParam>
String parentId = uniqueValue + "_" + FormUtil.getElementParameterName(this);
// after:  <gridParam>_<uniqueValue>
String parentId = FormUtil.getElementParameterName(this) + "_" + uniqueValue;
```

…but it did **not** update the matching row-id lookup in `getRows()`, which still rebuilt the prefix in the old order (`uv + "_" + param`).

Consequently:
1. The hidden `id` field is posted as `<param>_<uv>_id`, but `getRows()` looked for `<uv>_<param>_id`, so **`rId` never resolved**.
2. With `rId == null`, `rowData` passed to `getSubmittedData()` is always `null`, so the subform's **load-binder data is never set** (that block is guarded by `if (rowData != null)`).
3. On store, Joget core resolves a readonly field's value via `FormUtil.getElementPropertyValues()`. Readonly fields don't post their own value, so the only fallbacks are the `fk_` hidden param or the load-binder value. With the load-binder fallback gone, readonly fields collapse to empty and get persisted as empty strings.

This is why the defect is build-dependent: environments running a plugin build from before `e4bc19d` (where both orderings agreed) preserve readonly values.

## Fix

Realign `getRows()` to build `paramPrefix` as `param + "_" + uv`, matching the naming produced by `createForm()`. The multi-page-form fix from `e4bc19d` is preserved (the parameter-copy loops already use order-agnostic matching).

## Additional changes

- Bump plugin version to **8.0.6** (`pom.xml` + `Activator.VERSION`).
- Update the `wflow-core` dependency from `7.0-SNAPSHOT` to **`8.0-SNAPSHOT`** so the 8.0.x source (`Grid.getPropertyString`, `selfValidate`, current `Element` hierarchy) compiles from the committed pom.

## Testing

- `mvn clean package` → `BUILD SUCCESS`, produces `subform_repeater-8.0.6.jar`.