### PR TITLE
Fixed: Subform Repeater readonly child fields lose values when saved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.joget</groupId>
     <artifactId>subform_repeater</artifactId>
     <packaging>bundle</packaging>
-    <version>8.0.5</version>
+    <version>8.0.6</version>
     <name>subform_repeater</name>
     <url>https://www.joget.org</url>
     <properties>
@@ -78,6 +78,10 @@
                 <exclusion>
                     <groupId>javax.servlet</groupId>
                     <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.aspectj</groupId>
+                    <artifactId>aspectjweaver</artifactId>
                 </exclusion>
             </exclusions>
             <scope>provided</scope>

--- a/src/main/java/org/joget/Activator.java
+++ b/src/main/java/org/joget/Activator.java
@@ -7,7 +7,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 public class Activator implements BundleActivator {
-        public final static String VERSION = "8.0.5";
+        public final static String VERSION = "8.0.6";
 
 
     protected Collection<ServiceRegistration> registrationList;

--- a/src/main/java/org/joget/SubformRepeater.java
+++ b/src/main/java/org/joget/SubformRepeater.java
@@ -147,7 +147,7 @@ public class SubformRepeater extends Grid implements PluginWebSupport {
 
                     for (String uv : uniqueValues) {
                         if (!uv.isEmpty()) {
-                            String paramPrefix = uv + "_" + param;
+                            String paramPrefix = param + "_" + uv; // realign getRows() with createForm()/updateElement() child element parameter naming
                             String rId = formData.getRequestParameter(paramPrefix + "_" + FormUtil.PROPERTY_ID);
                             FormRow r = null;
                             if ("disable".equals(getPropertyString("editMode")) && rId != null && !rId.isEmpty() && existing.containsKey(rId)) {
@@ -189,6 +189,17 @@ public class SubformRepeater extends Grid implements PluginWebSupport {
             FormRowSet rowSet = new FormRowSet();
             rowSet.add(rowData);
             rowFormData.setLoadBinderData(loadBinder, rowSet);
+
+            //also recursively load binder data for nested elements (e.g. Multi Paged Form/Subform),
+            //matching getRowTemplate(), so their readonly fields resolve to the stored value on submit
+            //instead of falling back to an empty value and wiping out previously saved data
+            rowFormData.setPrimaryKeyValue(rowData.getId());
+            Collection<Element> loadChildren = form.getChildren(rowFormData);
+            if (loadChildren != null) {
+                for (Element child : loadChildren) {
+                    FormUtil.executeLoadBinders(child, rowFormData);
+                }
+            }
         }
         FormUtil.executeElementFormatDataForValidation(form, rowFormData);
         FormUtil.executeElementFormatData(form, rowFormData);


### PR DESCRIPTION
Fix: Readonly fields inside a Multi-Paged Form (nested in Subform Repeater) were wiped to empty on parent save. Corrected the row parameter prefix ordering and added recursive load-binder/primary-key propagation on submit so nested readonly fields keep their stored values instead of falling back to empty.